### PR TITLE
fix: license_file is deprecated - use license_files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ url = https://github.com/AleksaC/hadolint-py
 author = Aleksa Cukovic
 author_email = aleksacukovic1@gmail.com
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3


### PR DESCRIPTION
We started getting a warning "The license_file parameter is deprecated, use license_files instead." on our CI environment:

```
stdout:
    Processing /home/circleci/.cache/pre-commit/repop_10r30z
      Preparing metadata (setup.py): started
      Preparing metadata (setup.py): finished with status 'done'
    Building wheels for collected packages: circleci-cli-py
      Building wheel for circleci-cli-py (setup.py): started
      Building wheel for circleci-cli-py (setup.py): finished with status 'error'
      Running setup.py clean for circleci-cli-py
    Failed to build circleci-cli-py
    
stderr:
      error: subprocess-exited-with-error
      
      × python setup.py bdist_wheel did not run successfully.
      │ exit code: 1
      ╰─> [18 lines of output]
          /home/circleci/.cache/pre-commit/repop_10r30z/py_env-python3.8/lib/python3.8/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
          !!
          
                  ********************************************************************************
                  The license_file parameter is deprecated, use license_files instead.
          
                  By 2023-Oct-30, you need to update your project and remove deprecated calls
                  or your builds will no longer be supported.
          
                  See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
                  ********************************************************************************
          
          !!
            parsed = self.parsers.get(option_name, lambda x: x)(value)
          running bdist_wheel
          running build
          running fetch_binaries
          error: [Errno 17] File exists: 'build/temp.linux-x86_64-cpython-38'
          [end of output]
      
      note: This error originates from a subprocess, and is likely not a problem with pip.
      ERROR: Failed building wheel for circleci-cli-py
    ERROR: Could not build wheels for circleci-cli-py, which is required to install pyproject.toml-based projects
    
Check the log at /home/circleci/.cache/pre-commit/pre-commit.log

Exited with code exit status 3
```
(note that the warning is not an error but we never saw it until today because it was green otherwise).

This PR fixes the warning.
