### PR TITLE
Refactor pre-commit hook to match any file inside circleci folder

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,4 @@
   description: Validate CircleCI config without having to install the cli globally
   entry: env CIRCLECI_CLI_SKIP_UPDATE_CHECK=true circleci config validate -c
   language: python
-  files: \.circleci/config.yml
+  files: \.circleci/*


### PR DESCRIPTION
This will allow people that use dynamic configuration to validate all files inside the .circleci folder.


Currently:
```
.
└── .circleci/
    ├── config.yml # Validated
    └── continue-config.yml # Not validated
```

With this PR:
```
.
└── .circleci/
    ├── config.yml # Validated
    └── continue-config.yml # Validated
```

With it the user won't have to specify files to be formatted in the hook like this:

```
- repo: https://github.com/AleksaC/circleci-cli-py
  rev: v0.1.30549
  hooks:
    - id: circle-ci-validator
      files: \.circleci/*
```

Let me know if there are any additional changes that need to be made and if it sounds a nice idea.