### PR TITLE
Remove -c flag so arguments are correctly handled

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: circle-ci-validator
   name: CircleCI Config Validation
   description: Validate CircleCI config without having to install the cli globally
-  entry: env CIRCLECI_CLI_SKIP_UPDATE_CHECK=true circleci config validate -c
+  entry: env CIRCLECI_CLI_SKIP_UPDATE_CHECK=true circleci config validate
   language: python
   files: \.circleci/config.yml


### PR DESCRIPTION
The `-c` flag means that any `args` passed are put into the wrong place (see #9). It is also not a documented flag when running `circleci config validate --help`. It is not needed to process the CircleCI config file, or a pattern of files e.g. `.circleci/*.yaml`, as the positional argument `<path>` is the documented way to pass paths.

The downside to this change is that multiple filepaths are no longer handled e.g. `-c circleci/config_1.yml circleci/config_2.yml`. However, `pre-commit` uses a _pattern of files_ so a list of multiple files should never be set by a user.

This has been tested by pointing a local CircleCI config at this git rev and running the checks with an `--org-slug` arg.